### PR TITLE
Converted tutorial data to intake catalog

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - pymc>=5.0.0
   - pytensor
   - patsy
+  - intake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
     "pymc >= 5.0.0",
     "patsy",
+    "intake",
 ]
 
 dynamic = ["version"]

--- a/ratingcurve/data/__init__.py
+++ b/ratingcurve/data/__init__.py
@@ -9,18 +9,20 @@ from intake import open_catalog
 if TYPE_CHECKING:
     from pandas import DataFrame
 
-cat = open_catalog('catalog.yaml')
+cat = open_catalog('ratingcurve/data/catalog.yaml')
 
-def list() -> list:
+def list() -> tuple:
     """
-    Returns a list of names for the tutorial datasets.
+    Returns a tuple of names for the tutorial datasets.
 
     Returns
     -------
-    datasets : list of str
-        List of names of tutorial datasets.
+    datasets : tuple of str
+        Tuple of names of tutorial datasets.
     """
-    return list(cat)
+    datasets = tuple(cat)
+    
+    return datasets
 
 
 def load(name: str) -> DataFrame:
@@ -38,8 +40,8 @@ def load(name: str) -> DataFrame:
         Dataframe with the tutorial data. Columns include `h` (stage) and `q` (discharge), and
         potentially `q_sigma` (discharge uncertainty).
     """
-    if name not in list(cat):
-        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list(cat)}')
+    if name not in tuple(cat):
+        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {tuple(cat)}')
     
     return cat[name].read()
 
@@ -53,8 +55,8 @@ def describe(name: str):
     name : str
         Name of the dataset (e.g., 'green channel').
     """
-    if name not in list(cat):
-        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list(cat)}')
+    if name not in tuple(cat):
+        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {tuple(cat)}')
 
     print(cat[name].description)
     

--- a/ratingcurve/data/__init__.py
+++ b/ratingcurve/data/__init__.py
@@ -1,72 +1,60 @@
-"""Example datasets for rating curve analysis.
-"""
+"""Example datasets for rating curve analysis."""
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pkg_resources
 
-from pandas import read_csv
-
+from intake import open_catalog
 
 if TYPE_CHECKING:
     from pandas import DataFrame
 
-DATASETS = {
-    'chalk artificial': 'chalk_artificial',
-    'co channel': 'co_channel',
-    'green channel': 'green_channel',
-    'provo natural': 'provo_natural',
-    '3-segment simulated': 'simulated_rating'
-}
-
+cat = open_catalog('catalog.yaml')
 
 def list() -> list:
-    """Returns a list of tutorial datasets
+    """
+    Returns a list of names for the tutorial datasets.
 
     Returns
     -------
-    list
-        List of tutorial datasets
+    datasets : list of str
+        List of names of tutorial datasets.
     """
-    return [key for key in DATASETS.keys()]
+    return list(cat)
 
 
 def load(name: str) -> DataFrame:
-    """Opens a tutorial dataset
-
-    Parameters
-    ----------
-    name : str
-        Name of the dataset.
-        e.g., 'green channel'
-
-    Returns
     """
-    if name not in DATASETS.keys():
-        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list()}')
-    
-    filename = DATASETS.get(name) + '.csv'
-    stream = pkg_resources.resource_stream(__name__, filename)
-    return read_csv(stream)
-
-
-def describe(name) -> str:
-    """Describes a tutorial dataset
+    Opens a tutorial dataset.
 
     Parameters
     ----------
     name : str
-        Name of the dataset.
-        e.g., 'green channel'
+        Name of the dataset (e.g., 'green channel').
 
     Returns
     -------
-    str
-        Description of the dataset
+    dataset : DataFrame
+        Dataframe with the tutorial data. Columns include `h` (stage) and `q` (discharge), and
+        potentially `q_sigma` (discharge uncertainty).
     """
-    if name not in DATASETS.keys():
-        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list()}')
+    if name not in list(cat):
+        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list(cat)}')
+    
+    return cat[name].read()
 
-    filename = DATASETS.get(name) + '.md'
-    stream = pkg_resources.resource_stream(__name__, filename)
-    print(stream.read().decode('utf-8'))
+
+def describe(name: str):
+    """
+    Prints description of a tutorial dataset.
+
+    Parameters
+    ----------
+    name : str
+        Name of the dataset (e.g., 'green channel').
+    """
+    if name not in list(cat):
+        raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list(cat)}')
+
+    print(cat[name].description)
+    

--- a/ratingcurve/data/catalog.yaml
+++ b/ratingcurve/data/catalog.yaml
@@ -24,7 +24,7 @@ sources:
                 - Section control: 2.88 to 4 ft
     driver: csv
     args:
-      urlpath: 'chalk_artificial.csv'
+      urlpath: 'ratingcurve/data/chalk_artificial.csv'
 
   co channel:
     description: |-
@@ -42,7 +42,7 @@ sources:
                 - Channel control: 4.0 to 22.0 ft
     driver: csv
     args:
-      urlpath: 'co_channel.csv'
+      urlpath: 'ratingcurve/data/co_channel.csv'
 
   green channel:
     description: |-
@@ -66,7 +66,7 @@ sources:
                 - Channel control: 3.70 to 14 ft
     driver: csv
     args:
-      urlpath: 'green_channel.csv'
+      urlpath: 'ratingcurve/data/green_channel.csv'
 
   provo natural:
     description: |-
@@ -88,7 +88,7 @@ sources:
                 - Channel control:
     driver: csv
     args:
-      urlpath: 'provo_natural.csv'
+      urlpath: 'ratingcurve/data/provo_natural.csv'
 
   simulated rating:
     description: |-
@@ -106,4 +106,4 @@ sources:
                 - Overbank control: 10 to 12.18 ft
     driver: csv
     args:
-      urlpath: 'simulated_rating.csv'
+      urlpath: 'ratingcurve/data/simulated_rating.csv'

--- a/ratingcurve/data/catalog.yaml
+++ b/ratingcurve/data/catalog.yaml
@@ -1,0 +1,109 @@
+metadata:
+  version: 1
+  parameters:
+    file_name:
+      type: str
+      description: default file name for child entries
+      default: example_file_name
+      
+sources:
+  chalk artificial:
+    description: |-
+                # Chalk Creek at Coalville, UT (section control)
+
+                ## USGS Gage ID: 10131000
+                
+                ## Control
+                The streambed is composed of gravel, sand, and silt.
+                The channel is straight for 150 feet above the gage and 100 feet below the station.
+                The banks are fairly steep through the gage reach, especially the left bank.
+                The right bank is fairly protected from erosion due to an abundance of willow and cottonwood trees that grow along the bank.
+                A concrete Ogee weir is the hydraulic control for all but the highest of flows which are under channel control.
+                
+                ## Stage Ranges
+                - Section control: 2.88 to 4 ft
+    driver: csv
+    args:
+      urlpath: 'chalk_artificial.csv'
+
+  co channel:
+    description: |-
+                # Colorado River at Potash, UT (channel control)
+
+                ## USGS Gage ID: 09185600
+                
+                ## Control
+                The stream reach is in an incised river canyon in sandstone and mudstone. 
+                Channel control is in affect at all stages. 
+                A sharp bend of the river is present just upstream of the gage. 
+                The channel is straight for about 1,000 ft downstream before it begins a broad bend to the right.
+                
+                ## Stage Ranges
+                - Channel control: 4.0 to 22.0 ft
+    driver: csv
+    args:
+      urlpath: 'co_channel.csv'
+
+  green channel:
+    description: |-
+                # Green River near Jensen, UT (channel control)
+                
+                ## USGS Gage ID: 09261000
+                
+                ## Control
+                At the gage, the river is restricted to one channel at all stages.
+                The streambed is very flat and is composed of cobbles.
+                The banks consist of sand, gravel and cobbles.
+                Riparian vegetation includes sage brush, willows, greasewood, and tamarisk.
+                The left bank is not as steep as the right, which slopes up quite abruptly.
+                Both banks are quite stable and are not subject to overflow except at extremely high stages.
+                The channel is straight for several hundred yards upstream but bends sharply to the right about 2,000 feet below the station.
+                Channel control prevails at all but the lowest stages when a rocky riffle 200 feet below the gage becomes effective.
+                The riffle is quite stable. 
+                
+                ## Stage Ranges
+                - Reach control: < 3.70 ft
+                - Channel control: 3.70 to 14 ft
+    driver: csv
+    args:
+      urlpath: 'green_channel.csv'
+
+  provo natural:
+    description: |-
+                # Provo River near Woodland, UT (single offset)
+
+                ## USGS Gage ID: 10154200
+                
+                ## Control
+                The channel is fairly straight for about 300 feet above and 30 feet below gage where it starts to bend left.
+                The streambed is composed of rounded cobbles and boulders, and the gradient is fairly steep in the vicinity of the gage.
+                The low to medium flow control is a rocky riffle about 80 feet below the gage, and during high flow channel geometry becomes the control.
+                Both banks are rather rocky with a slope of about 45 degrees and are generally not subject to overflow.
+                Both section and channel controls present, but due to channel roughness and slope a single straight-line rating segment 
+                (single offset) represents the stage discharge relation for both controls.
+                This is common in high gradient cobble or larger substrate streams.
+                
+                ## Stage Ranges
+                - Reach control: 
+                - Channel control:
+    driver: csv
+    args:
+      urlpath: 'provo_natural.csv'
+
+  simulated rating:
+    description: |-
+                # Simulated 3 segment rating (section, channel, and overbank controls)
+
+                ## Control
+                A synthetic compound channel was developed for the purposes of simulating streamflows to develop a theoretically defined rating curve.
+                The rectangular main channel is 100 feet wide and 5 feet tall. A section control resembling a obtuse angled weir roughly 0.3 ft above 
+                the main channel bed was inserted downstream of the gaged cross section. 
+                Floodplains on either side were each 715 ft wide.
+                
+                ## Stage Ranges
+                - Section control: 5.0 to 5.75 ft
+                - Channel control: 5.75 to 10 ft
+                - Overbank control: 10 to 12.18 ft
+    driver: csv
+    args:
+      urlpath: 'simulated_rating.csv'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pymc>=5.0.0
 pandas
 pytensor
 patsy
+intake


### PR DESCRIPTION
Created [`intake`](https://intake.readthedocs.io/en/latest/catalog.html#local-catalogs) catalog for local datasets. Updated method to read in local tutorial datasets to use this intake catalog. User interaction with loading and seeing dataset descriptions has not changed.