### PR TITLE
Modelbuilder API doc fix

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To improve that process, the U.S. Geological Survey (USGS), among others, is eva
 Several automated methods currently exist, but each parameterizes the rating curve slightly differently,
 and because of the nature of the problem, those slight differences can greatly affect performance.
 To help the community evaluate different parameterizations,
-we created the `ratingcurve' package, which implements our best parameterization for others to try.
+we created the `ratingcurve` package, which implements our best parameterization for others to try.
 Furthermore, the implementation uses [PyMC](https://www.pymc.io/welcome.html), a general purpose library for probabilistic modeling, 
 which makes it easier for others to modify the model to test different parameterizations or fitting algorithms.
 If you can improve upon our parameterization, USGS might use your algorithm to generate streamflow timeseries at thousands of locations around the United States.
@@ -33,28 +33,27 @@ This [`tutorial`](https://github.com/thodson-usgs/ratingcurve/blob/main/docs/not
 Here's a simple example that fits and plots a rating curve.
 
 ```python
-from ratingcurve.ratingmodel import PowerLawRating
+from ratingcurve.ratings import PowerLawRating
 from ratingcurve import data
 
 # load tutorial data
 df = data.load('green channel')
 
 # initialize the model
-powerrating = PowerLawRating(q=df['q'],
-                             h=df['stage'], 
-                             q_sigma=df['q_sigma'],
-                             segments=2)
+powerrating = PowerLawRating(segments=2)
                                    
 # fit the model
-trace = powerrating.fit()
-powerrating.plot(trace)
+trace = powerrating.fit(q=df['q'],
+                        h=df['stage'], 
+                        q_sigma=df['q_sigma'])
+powerrating.plot()
 ```
 ![example plot](https://github.com/thodson-usgs/ratingcurve/blob/main/docs/assets/green-channel-rating-plot.png?raw=true)
 
 
 Once fit, easily generate a rating table that can be imported into other applications.
 ```python
-powerrating.table(trace)
+powerrating.table()
 ```
 
 For more, see the [documentation](https://thodson-usgs.github.io/ratingcurve/meta/intro.html).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,7 +13,7 @@ only_build_toc_files: True
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
-  timeout: 600
+  timeout: 1200
   allow_errors: True
 
 # Define the name of the latex output file for PDF builds

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,11 +1,15 @@
 API Reference
 =============
 
-.. automodule:: ratingcurve.ratingmodel
+.. automodule:: ratingcurve.ratingmodel_builder
     :members:
-.. automodule:: ratingcurve.transform
+.. automodule:: ratingcurve.ratings
     :members:
 .. automodule:: ratingcurve.plot
     :members:
-.. automodule:: ratingcurve.sklearn
+.. automodule:: ratingcurve.transform
+    :members:
+.. automodule:: ratingcurve.data
+    :members:
+.. automodule:: ratingcurve.experimental_ratings
     :members:


### PR DESCRIPTION
The API rst did not get updated with the other docs. So, the online documentation is failing to compile since the old rst points to non-existent files. This fixes the problem.