### PR TITLE
Updated how table extends data

### DIFF
--- a/ratingcurve/ratingmodel_builder.py
+++ b/ratingcurve/ratingmodel_builder.py
@@ -498,7 +498,7 @@ class RatingModelBuilder(ModelBuilder):
         step : float, optional
             Step size for stage values.
         extend : float, optional
-            Extend range of discharge values by this factor.
+            Extend range of stage values by this factor.
 
         Returns
         -------
@@ -526,8 +526,9 @@ class RatingModelBuilder(ModelBuilder):
                            'gse': np.exp(np.std(np.log(ratingdata),
                                                 axis=1))})
 
-        discharge_limit = self.q_obs.max() * extend
-        return df[df['discharge'] <= discharge_limit]
+        # discharge_limit = self.q_obs.max() * extend
+        # return df[df['discharge'] <= discharge_limit]
+        return df
 
     def residuals(self) -> ArrayLike:
         """Compute residuals of rating model.


### PR DESCRIPTION
The `table` method limited the extended prediction range to only include discharge values `<= max(discharge) * 1.1`. This seems confusing for a user, since one would typically want to extend stage and not discharge (i.e., extend the observed data range and see the resulting predictions). I have simply updated `table` method to not truncate the tabled data by discharge.