### PR TITLE
Bump PyMC to >=5.21 and fix compatibility issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ name: ratingcurve
 channels:
   - conda-forge
 dependencies:
-  - pymc>=5.0.0
+  - pymc>=5.21
   - pytensor
   - patsy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "pymc >= 5.0.0",
+    "pymc >= 5.21",
     "patsy",
 ]
 

--- a/ratingcurve/data/__init__.py
+++ b/ratingcurve/data/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
-import pkg_resources
+from importlib import resources
 
 from pandas import read_csv
 
@@ -50,8 +50,9 @@ def load(name: str) -> DataFrame:
         raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list()}')
 
     filename = DATASETS.get(name) + '.csv'
-    stream = pkg_resources.resource_stream(__name__, filename)
-    return read_csv(stream)
+    source = resources.files(__package__).joinpath(filename)
+    with resources.as_file(source) as path:
+        return read_csv(path)
 
 
 def describe(name) -> str:
@@ -72,5 +73,5 @@ def describe(name) -> str:
         raise ValueError(f'Dataset "{name}" does not exist. Valid values are: {list()}')
 
     filename = DATASETS.get(name) + '.md'
-    stream = pkg_resources.resource_stream(__name__, filename)
-    print(stream.read().decode('utf-8'))
+    source = resources.files(__package__).joinpath(filename)
+    print(source.read_text(encoding='utf-8'))

--- a/ratingcurve/experimental_ratings.py
+++ b/ratingcurve/experimental_ratings.py
@@ -6,7 +6,7 @@ import numpy as np
 import pymc as pm
 import pytensor.tensor as at
 
-from .modelbuilder_ratings import PowerLawRating
+from .ratings import PowerLawRating
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike


### PR DESCRIPTION
## Summary
- Bumps PyMC version constraint from `>=5.0.0` to `>=5.21` in `pyproject.toml` and `environment.yml` (tested with PyMC 5.28.4)
- Replaces deprecated `pkg_resources` with `importlib.resources` in `ratingcurve/data/__init__.py` (fixes import error on Python 3.12+)
- Fixes broken import in `experimental_ratings.py` (`modelbuilder_ratings` → `ratings`)

Closes #70

## Test plan
- [x] All 205 tests pass (185 passed, 20 expected failures) with PyMC 5.28.4
- [x] NUTS and ADVI fitting tests pass
- [x] Data loading tests pass with new `importlib.resources` usage
- [x] Transform tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)