### PR TITLE
Address review comments from #72

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include ratingcurve/data/*.csv
+include ratingcurve/data/*.md

--- a/ratingcurve/data/__init__.py
+++ b/ratingcurve/data/__init__.py
@@ -74,4 +74,4 @@ def describe(name) -> str:
 
     filename = DATASETS.get(name) + '.md'
     source = resources.files(__package__).joinpath(filename)
-    print(source.read_text(encoding='utf-8'))
+    return source.read_text(encoding='utf-8')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymc>=5.0.0
+pymc>=5.21
 pandas
 pytensor
 patsy


### PR DESCRIPTION
## Summary
Addresses the three review comments from Copilot on #72:

- **`describe()` return type**: Changed from `print()` to `return`, matching the `-> str` annotation. Callers who relied on the print side-effect should now use `print(data.describe(...))`.
- **Package data in wheels**: Added `include ratingcurve/data/*.md` to `MANIFEST.in` so dataset description files are included alongside CSVs in built distributions.
- **Inconsistent version pins**: Updated `requirements.txt` from `pymc>=5.0.0` to `pymc>=5.21` to match `pyproject.toml` and `environment.yml`.

## Test plan
- [x] `data.describe('green channel')` returns a string
- [x] All 198 data/transform tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)