### PR TITLE
Add equation() method to PowerLawRating

### DIFF
--- a/examples/print_equation.py
+++ b/examples/print_equation.py
@@ -1,0 +1,43 @@
+"""Print the power-law rating equation from a fitted model.
+
+Demonstrates how to extract and display the parametric equation
+for a multi-segment power-law rating curve.
+"""
+import numpy as np
+from ratingcurve.ratings import PowerLawRating
+from ratingcurve import data
+
+# Load sample data and fit a 2-segment model
+df = data.load('green channel')
+rating = PowerLawRating(segments=2)
+rating.fit(df['stage'], df['q'], q_sigma=df['q_sigma'])
+
+# Get the denormalized equation parameters
+params = rating.equation()
+
+# Print the equation
+segments = len(params['b'])
+
+print("Rating curve equation")
+print("=====================")
+print()
+print("  ln(q) = a + sum(b[i] * ln(max(h - hs[i], 0) + ho[i]))")
+print()
+print("where ho[0] = 0 and ho[i] = 1 for i > 0")
+print()
+print(f"  a  = {params['a']:.4f}")
+for i in range(segments):
+    print(f"  b[{i}] = {params['b'][i]:.4f},  hs[{i}] = {params['hs'][i]:.4f}")
+print()
+
+# Build the full equation string
+terms = []
+for i in range(segments):
+    ho = 0 if i == 0 else 1
+    if ho == 0:
+        terms.append(f"{params['b'][i]:.4f} * ln(max(h - {params['hs'][i]:.4f}, 0))")
+    else:
+        terms.append(f"{params['b'][i]:.4f} * ln(max(h - {params['hs'][i]:.4f}, 0) + 1)")
+
+eq_str = f"ln(q) = {params['a']:.4f} + " + " + ".join(terms)
+print(eq_str)

--- a/ratingcurve/ratings.py
+++ b/ratingcurve/ratings.py
@@ -7,7 +7,7 @@ import pymc as pm
 import pytensor.tensor as at
 
 from .transform import Dmatrix
-from .plot import PowerLawPlotMixin, SplinePlotMixin
+from .plot import PowerLawPlotMixin, SplinePlotMixin, is_fit
 from .ratingmodel_builder import RatingModelBuilder
 
 if TYPE_CHECKING:
@@ -129,6 +129,39 @@ class PowerLawRating(RatingModelBuilder, PowerLawPlotMixin):
                             sigma=np.sqrt(sigma**2 + q_sigma**2),
                             shape=h.shape,
                             observed=log_q_z)
+
+    @is_fit
+    def equation(self):
+        """Return denormalized power-law equation parameters.
+
+        Transforms the fitted model parameters from normalized log-space
+        back to the standard power-law form::
+
+            ln(q) = a + sum(b[i] * ln(max(h - hs[i], 0) + ho[i]))
+
+        where ``ho[0] = 0`` and ``ho[i] = 1`` for ``i > 0``.
+
+        Returns
+        -------
+        params : dict
+            Dictionary with keys:
+            - ``'a'`` : float, intercept
+            - ``'b'`` : ndarray, exponents for each segment
+            - ``'hs'`` : ndarray, breakpoint stages
+        """
+        posterior = self.idata.posterior
+        a_z = posterior['a'].mean().item()
+        b_z = posterior['b'].mean(dim=['chain', 'draw']).values.flatten()
+        hs = posterior['hs'].mean(dim=['chain', 'draw']).values.flatten()
+
+        mu = self.q_transform.mean_
+        std = self.q_transform.std_
+
+        return {
+            'a': mu + std * a_z,
+            'b': std * b_z,
+            'hs': hs,
+        }
 
     def set_normal_prior(self):
         """Set normal prior for breakpoints.

--- a/ratingcurve/tests/test_fitting.py
+++ b/ratingcurve/tests/test_fitting.py
@@ -58,6 +58,41 @@ def test_no_zero_flows():
         _ = rating.fit(h, q)
 
 
+def test_equation():
+    """Test that equation() returns denormalized parameters that reproduce
+    the rating table."""
+    df = data.load('green channel')
+    rating = PowerLawRating(segments=2)
+    rating.fit(df['stage'], df['q'], q_sigma=df['q_sigma'])
+
+    params = rating.equation()
+
+    assert 'a' in params
+    assert 'b' in params
+    assert 'hs' in params
+    assert len(params['b']) == 2
+    assert len(params['hs']) == 2
+
+    # Verify equation reproduces table output
+    table = rating.table()
+    h = table['stage'].values
+
+    ho = np.ones(2)
+    ho[0] = 0
+
+    log_q = params['a']
+    for i in range(2):
+        log_q = log_q + params['b'][i] * np.log(
+            np.clip(h - params['hs'][i], 0, np.inf) + ho[i]
+        )
+
+    q_eq = np.exp(log_q)
+
+    # The equation with posterior means should approximate the table median.
+    # Use a loose tolerance since mean of posterior != exact median prediction.
+    np.testing.assert_allclose(q_eq, table['median'].values, rtol=0.15)
+
+
 def test_zero_flow_prior():
     """
     Test the zero-flow prior.


### PR DESCRIPTION
## Summary
- Adds an `equation()` convenience method to `PowerLawRating` that returns denormalized power-law parameters (`a`, `b`, `hs`) so users can reconstruct the standard rating equation directly
- Adds a test verifying the denormalized parameters reproduce the rating table output
- Adds an example script (`examples/print_equation.py`) demonstrating how to extract and display the parametric equation

Closes #65

## Details

The PyMC model fits parameters in normalized log-space (z-scored via `LogZTransform`). The `summary()` method returns these raw normalized parameters, but users expect parameters for the standard equation:

```
ln(q) = a + sum(b[i] * ln(max(h - hs[i], 0) + ho[i]))
```

The `equation()` method denormalizes `a` and `b` using the stored transform statistics (`q_transform.mean_` and `q_transform.std_`), while `hs` values are already in raw stage space.

## Test plan
- [x] `pytest ratingcurve/tests/test_fitting.py::test_equation -xvs` passes
- [ ] Verify example script runs: `python examples/print_equation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)